### PR TITLE
Fixing placement for append-to-body dropdowns

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -91,7 +91,6 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     appendTo = null,
     keynavEnabled = false,
     selectedOption = null,
-    dropUp = $element.hasClass('dropup'),
     body = $document.find('body');
 
   $element.addClass('dropdown');
@@ -199,36 +198,28 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   scope.$watch('isOpen', function(isOpen, wasOpen) {
     if (appendTo && self.dropdownMenu) {
-      var placement = 'bottom-left';
-      if (dropUp) {
-        placement = 'top-left';
+      var dropUp = $element.hasClass('dropup');
+      var rightalign = self.dropdownMenu.hasClass('dropdown-menu-right');
+      var placement = 'auto bottom-left';
+      if(dropUp && rightalign){
+        placement = 'auto top-right';
+      } else if (dropUp) {
+        placement = 'auto top-left';
+      } else if (rightalign) {
+        placement = 'auto bottom-right';
       }
+     
       var pos = $position.positionElements($element, self.dropdownMenu, placement, true),
         css,
-        rightalign,
         scrollbarPadding,
         scrollbarWidth = 0;
 
       css = {
         top: pos.top + 'px',
+        left: pos.left + 'px',
+        right: 'auto',
         display: isOpen ? 'block' : 'none'
       };
-
-      rightalign = self.dropdownMenu.hasClass('dropdown-menu-right');
-      if (!rightalign) {
-        css.left = pos.left + 'px';
-        css.right = 'auto';
-      } else {
-        css.left = 'auto';
-        scrollbarPadding = $position.scrollbarPadding(appendTo);
-
-        if (scrollbarPadding.heightOverflow && scrollbarPadding.scrollbarWidth) {
-          scrollbarWidth = scrollbarPadding.scrollbarWidth;
-        }
-
-        css.right = window.innerWidth - scrollbarWidth -
-          (pos.left + $element.prop('offsetWidth')) + 'px';
-      }
 
       // Need to adjust our positioning to be relative to the appendTo container
       // if it's not the body element
@@ -243,13 +234,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
           css.right = window.innerWidth -
             (pos.left - appendOffset.left + $element.prop('offsetWidth')) + 'px';
         }
-      }
-
-      // If the menu is a drop up, it needs to be repositioned based the menu height
-      // and 4px to achieve the same effect as bootstrap
-      if(dropUp) {
-        css.top = pos.top - self.dropdownMenu.outerHeight() - 4 + 'px';
-      }
+      } 
 
       self.dropdownMenu.css(css);
     }

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -91,6 +91,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     appendTo = null,
     keynavEnabled = false,
     selectedOption = null,
+    dropUp = $element.hasClass('dropup'),
     body = $document.find('body');
 
   $element.addClass('dropdown');
@@ -198,7 +199,11 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   scope.$watch('isOpen', function(isOpen, wasOpen) {
     if (appendTo && self.dropdownMenu) {
-      var pos = $position.positionElements($element, self.dropdownMenu, 'bottom-left', true),
+      var placement = 'bottom-left';
+      if (dropUp) {
+        placement = 'top-left';
+      }
+      var pos = $position.positionElements($element, self.dropdownMenu, placement, true),
         css,
         rightalign,
         scrollbarPadding,
@@ -238,6 +243,12 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
           css.right = window.innerWidth -
             (pos.left - appendOffset.left + $element.prop('offsetWidth')) + 'px';
         }
+      }
+
+      // If the menu is a drop up, it needs to be repositioned based the menu height
+      // and 4px to achieve the same effect as bootstrap
+      if(dropUp) {
+        css.top = pos.top - self.dropdownMenu.outerHeight() - 4 + 'px';
       }
 
       self.dropdownMenu.css(css);

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -432,12 +432,12 @@ angular.module('ui.bootstrap.position', [])
        *   </ul>
        */
       positionElements: function(hostElem, targetElem, placement, appendToBody) {
+        //Use the DOM element to find the height and width prior to using the raw node
+        var targetHeight = targetElem.innerHeight();
+        var targetWidth = targetElem.innerWidth();
+        
         hostElem = this.getRawNode(hostElem);
         targetElem = this.getRawNode(targetElem);
-
-        // need to read from prop to support tests.
-        var targetWidth = angular.isDefined(targetElem.offsetWidth) ? targetElem.offsetWidth : targetElem.prop('offsetWidth');
-        var targetHeight = angular.isDefined(targetElem.offsetHeight) ? targetElem.offsetHeight : targetElem.prop('offsetHeight');
 
         placement = this.parsePlacement(placement);
 

--- a/src/position/test/position.spec.js
+++ b/src/position/test/position.spec.js
@@ -6,6 +6,13 @@ describe('$uibPosition service', function () {
     this.prop = function(propName) {
       return propName === 'offsetWidth' ? width : height;
     };
+
+    this.innerHeight = function() {
+      return height;
+    };
+    this.innerWidth = function() {
+      return width;
+    };
   };
 
   var $document;


### PR DESCRIPTION
Changed how positioning works with dropdown-menu-right and dropup classes, and so that the dropdown menu will reposition itself into another place if the default one doesn't fit
