### PR TITLE
feat(position): add 'positionElementAt' method

### DIFF
--- a/src/position/position.js
+++ b/src/position/position.js
@@ -483,8 +483,8 @@ angular.module('ui.bootstrap.position', [])
           bottom: $document[0].documentElement.clientHeight - clientCoordinates.clientY
         };
         var hostPosition = {
-          top: clientCoordinates.clientX,
-          left: clientCoordinates.clientY,
+          top: clientCoordinates.clientY,
+          left: clientCoordinates.clientX,
           height: 0,
           width: 0
         };

--- a/src/position/test/position.spec.js
+++ b/src/position/test/position.spec.js
@@ -404,7 +404,7 @@ describe('$uibPosition service', function () {
     beforeEach(function() {
       $uibPosition.positionElement = jasmine.createSpy('positionElement');
 
-      clientCoords = { clientX: 20, clientY: 20};
+      clientCoords = { clientX: 20, clientY: 10};
       placement = 'some-placement';
       targetElem = new TargetElMock(10, 10);
 
@@ -413,12 +413,12 @@ describe('$uibPosition service', function () {
     it('should call positionElement', function() {
       expect($uibPosition.positionElement).toHaveBeenCalledWith(
         {
-          top: clientCoords.clientX,
-          left: clientCoords.clientY,
+          top: clientCoords.clientY,
+          left: clientCoords.clientX,
           right: $document[0].documentElement.clientWidth - clientCoords.clientX,
           bottom: $document[0].documentElement.clientHeight - clientCoords.clientY
         },
-        { top: clientCoords.clientX, left: clientCoords.clientY, height: 0, width: 0 },
+        { top: clientCoords.clientY, left: clientCoords.clientX, height: 0, width: 0 },
         targetElem,
         placement
       );


### PR DESCRIPTION
Add a method to position an element at client x/y coordinates. Using
code from the positionElements method, which has been refactored into a
positionElement method with both positionElementAt and positionElements
use.