### PR TITLE
fix(dropdown): close dropdown on mousedown

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -10,7 +10,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   this.open = function(dropdownScope, element) {
     if (!openScope) {
-      $document.on('click', closeDropdown);
+      $document.on('click mousedown', closeDropdown);
     }
 
     if (openScope && openScope !== dropdownScope) {
@@ -22,7 +22,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   this.close = function(dropdownScope, element) {
     if (openScope === dropdownScope) {
-      $document.off('click', closeDropdown);
+      $document.off('click mousedown', closeDropdown);
       $document.off('keydown', this.keybindFilter);
       openScope = null;
     }


### PR DESCRIPTION
Using purely click as the event for dropdown interferes with drag and drop operations, which can result in strange effects if the dropdown anchor is moved by a drag operation