### PR TITLE
fix(dropdown): addendum to mousedown fix to allow menu click

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -31,6 +31,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     }
 
     openScope = dropdownScope;
+    openScope.getDropdownElement().on('click', closeDropdown);
   };
 
   this.close = function(dropdownScope, element) {
@@ -40,6 +41,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
       } else {
         $document.off('mousedown', closeDropdown);
         $document.off('keydown', this.keybindFilter);
+        openScope.getDropdownElement().off('click', closeDropdown);
         openScope = null;
       }
     }
@@ -64,6 +66,11 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
       dropdownElement && dropdownElement[0].contains(evt.target)) {
       return;
     }
+
+    if (evt && dropdownElement && 
+      evt.type === 'mousedown' && dropdownElement[0].contains(evt.target)) {
+      return;
+    } 
 
     openScope.focusToggleElement();
     openScope.isOpen = false;

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -57,7 +57,7 @@ describe('uib-dropdown', function() {
       expect(element).toHaveClass(dropdownConfig.openClass);
 
       var optionEl = element.find('ul > li').eq(0).find('a').eq(0);
-      optionEl.mousedown();
+      optionEl.click();
       expect(element).not.toHaveClass(dropdownConfig.openClass);
     });
 
@@ -257,7 +257,7 @@ describe('uib-dropdown', function() {
           beforeEach(function() {
             menu = $document.find('#dropdown-menu a');
             menu.focus();
-            menu.trigger('mousedown');
+            menu.trigger('click');
           });
           it('focuses the dropdown element on close', function() {
             expect(document.activeElement).toBe(toggle[0]);
@@ -321,7 +321,7 @@ describe('uib-dropdown', function() {
             beforeEach(function() {
               menu = $document.find('#dropdown-menu a');
               menu.focus();
-              menu.trigger('mousedown');
+              menu.trigger('click');
             });
             it('focuses the dropdown element on close', function() {
               expect(document.activeElement).toBe(toggle[0]);
@@ -382,7 +382,7 @@ describe('uib-dropdown', function() {
             beforeEach(function() {
               menu = $document.find('#dropdown-menu a');
               menu.focus();
-              menu.trigger('mousedown');
+              menu.trigger('click');
             });
             it('focuses the dropdown element on close', function() {
               expect(document.activeElement).toBe(toggle[0]);
@@ -463,7 +463,7 @@ describe('uib-dropdown', function() {
         beforeEach(function() {
           menu = $document.find('#dropdown-menu a');
           menu.focus();
-          menu.trigger('mousedown');
+          menu.trigger('click');
         });
         it('focuses the dropdown element on close', function() {
           expect(document.activeElement).toBe(toggle[0]);


### PR DESCRIPTION
Previous commit featured a bug where clicking inside the menu would close it before any click handlers could run for menu items. The fix for this was to register a close handler on the menu and ignore the mousedown handler if the target is the dropdown.