### PR TITLE
fix(datepicker): maintain focus during keyboard nav

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -38,6 +38,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     $scope.datepickerOptions = {};
   }
 
+  $scope.maintainFocus = false;
+
   // Modes chain
   this.modes = ['day', 'month', 'year'];
 
@@ -212,6 +214,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       date = dateParser.fromTimezone(date, ngModelOptions.timezone);
       ngModelCtrl.$setValidity('dateDisabled', !date ||
         this.element && !this.isDisabled(date));
+
+      if ($scope.maintainFocus) {
+        $scope.$broadcast('uib:datepicker.focus');
+        $scope.maintainFocus = false;
+      }
     }
   };
 
@@ -264,6 +271,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 
   $scope.select = function(date) {
+    $scope.maintainFocus = true;
     if ($scope.datepickerMode === self.minMode) {
       var dt = ngModelCtrl.$viewValue ? dateParser.fromTimezone(new Date(ngModelCtrl.$viewValue), ngModelOptions.timezone) : new Date(0, 0, 0, 0, 0, 0, 0);
       dt.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
@@ -281,6 +289,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 
   $scope.move = function(direction) {
+    $scope.maintainFocus = true;
     var year = self.activeDate.getFullYear() + direction * (self.step.years || 0),
         month = self.activeDate.getMonth() + direction * (self.step.months || 0);
     self.activeDate.setFullYear(year, month, 1);
@@ -288,6 +297,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 
   $scope.toggleMode = function(direction) {
+    $scope.maintainFocus = true;
     direction = direction || 1;
 
     if ($scope.datepickerMode === self.maxMode && direction === 1 ||
@@ -304,7 +314,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   $scope.keys = { 13: 'enter', 32: 'space', 33: 'pageup', 34: 'pagedown', 35: 'end', 36: 'home', 37: 'left', 38: 'up', 39: 'right', 40: 'down' };
 
   var focusElement = function() {
-    self.element[0].focus();
+    var focusTarget = self.element[0].querySelector('[tabindex]:not([tabindex="-1"])');
+    focusTarget.focus();
   };
 
   // Listen for focus requests from popup directive


### PR DESCRIPTION
This isn't my favorite fix, but it's sort of an unfortunate necessity with how the datepicker works: the datepicker itself does all of the control logic, listening to key presses, etc; however, the child component per mode is what triggers a refreshView during it's initialization (which only works because it's ng-switch'ed in and out of existence).

