### PR TITLE
Bump the version, cherry pick missing changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "https://github.com/angular-ui/bootstrap/graphs/contributors",
   "name": "angular-ui-bootstrap",
-  "version": "2.2.0+inin.1.5",
+  "version": "2.2.0+inin.1.10",
   "homepage": "http://angular-ui.github.io/bootstrap/",
   "dependencies": {},
   "directories": {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -429,6 +429,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     scope.labels = new Array(7);
     for (var j = 0; j < 7; j++) {
       scope.labels[j] = {
+        date: days[j].date,
         abbr: dateFilter(days[j].date, this.formatDayHeader),
         full: dateFilter(days[j].date, 'EEEE')
       };


### PR DESCRIPTION
Everyone but @stormojm has been making changes to the branch `inin-master`, so I cherry picked down his change, which had been tagged inin.1.9 in `master`, thus the `1.10` here.

To make things more fun, the perforce version was never bumped to 1.9.  Sheesh

I feel like `inin-master` should just be merged up into master to avoid this sort of confusion in the future, but it wouldn't be a clean merge and would probably require testing.